### PR TITLE
Chain display implemented into THREAD page.

### DIFF
--- a/src/main/resources/static/scripts/getReplies.js
+++ b/src/main/resources/static/scripts/getReplies.js
@@ -13,7 +13,7 @@ function getReplies(level, id) {
                 $("."+id).append("<div onclick='getReplies("
                     + (level+1) +", &#39;"
                     + i.id_str + "&#39;)' class= '"
-                    + (level+1) + " unclicked "
+                    + level + " unclicked "
                     + i.id_str +"'><p>"
                     + i.full_text + "<br><a href='https://www.twitter.com/statuses/"
                     + i.id_str + "'>"

--- a/src/main/resources/static/styles/thread.css
+++ b/src/main/resources/static/styles/thread.css
@@ -1,0 +1,8 @@
+.chain{
+    width: 40%;
+    float: left;
+}
+
+.replies{
+    margin-left: 15%;
+}

--- a/src/main/resources/templates/discussion.html
+++ b/src/main/resources/templates/discussion.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
 <head th:include="fragments/commons :: head">
     <title id="pageTitle">Discussion</title>
+    <link id="pageStyle">
 </head>
 <body>
 <th:block th:include="fragments/commons :: header" />

--- a/src/main/resources/templates/fragments/commons.html
+++ b/src/main/resources/templates/fragments/commons.html
@@ -4,6 +4,7 @@
 <head th:fragment="head">
     <meta charset="UTF-8">
     <title th:include=":: #pageTitle">TWITREE</title>
+    <link th:replace=":: #pageStyle"> <!--This means every page must have a link in it.-->
     <script type="text/javascript" th:src="@{/scripts/jquery-3.3.1.js}"></script>
     <script type="text/javascript" th:src="@{/scripts/getReplies.js}"></script>
 </head>
@@ -15,10 +16,6 @@
         <input type="submit" value="THREAD" name="pressed">
         <input type="submit" value="DISCUSSION" name="pressed"></p>
     </form>
-</div>
-
-<div th:fragment="tweet" th:object="">
-
 </div>
 
 </body>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
 <head th:replace="fragments/commons :: head">
     <title id="pageTitle">TwiTree: Enhancing Twitter</title>
+    <link id="pageStyle">
 </head>
 <body>
     <th:block th:include="fragments/commons :: header" />

--- a/src/main/resources/templates/thread.html
+++ b/src/main/resources/templates/thread.html
@@ -2,10 +2,27 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
 <head th:include="fragments/commons :: head">
     <title id="pageTitle">Thread</title>
+    <link id="pageStyle" rel="stylesheet" th:href="@{/styles/thread.css}">
 </head>
 <body>
-<th:block th:include="fragments/commons :: header" />
-<button type="button" th:onclick="'getReplies(1,\'' + ${(initializerPack.initializer().getId())} + '\')'">Try it</button>
-<div th:class="${initializerPack.initializer().getId()}"><p>Hi there!</p></div>
+    <th:block th:include="fragments/commons :: header" />
+    <div class="chain">
+    <table>
+        <tr th:each="tweet: ${firstDisplay}" th:rowspan="2">
+            <td th:onclick="'getReplies(0,\'' + ${(initializerPack.initializer().getId())} + '\')'"><p>
+                <span th:text="${tweet.getText()}">Tweet text</span>
+            <br><a th:href="'https://www.twitter.com/statuses/'+${tweet.getId()}" th:text="${tweet.getCreatedAt()}"></a> </p></td>
+        </tr>
+    </table>
+    </div>
+    <div class="replies">
+        <table>
+            <tr th:each="tweet: ${firstDisplay}">
+                <td th:class="'unclicked '+ ${tweet.getId()}"></td>
+            </tr>
+        </table>
+    </div>
+    <!--<button type="button" th:onclick="'getReplies(1,\'' + ${(initializerPack.initializer().getId())} + '\')'">Try it</button>-->
+    <!--<div th:class="${initializerPack.initializer().getId()}"><p>Hi there!</p></div>-->
 </body>
 </html>


### PR DESCRIPTION
* FURTHER DEVELOPMENT
  * Created a basic formatting layout for threads. (thread.css)
  * Chain display utilizes firstDisplay as asked in prev. commit note.

* STILL/NEW LEFT TO DO
  * Utilize firstDisplay package passed into the model for DISCUSSION page.
  * Manage indentation.
  * Prevent multiple copies.
    * On THREAD, if possible, do not display replies that belong in chain.